### PR TITLE
Fix code scanning alert no. 1: Implicit narrowing conversion in compound assignment

### DIFF
--- a/src/main/java/ru/elliptica/collections/BitIndex.java
+++ b/src/main/java/ru/elliptica/collections/BitIndex.java
@@ -59,7 +59,7 @@ public abstract class BitIndex {
 
 	protected void index() {
 		long mask = globalMask;
-		short counter = 0;
+		int counter = 0;
 		int indIndex = 0;
 		for (int pos = Long.numberOfTrailingZeros(mask); mask != 0; mask &= ~(1L << pos), pos = Long.numberOfTrailingZeros(mask) ) {
 			counts[pos] = counter;


### PR DESCRIPTION
Fixes [https://github.com/mahairod/trie/security/code-scanning/1](https://github.com/mahairod/trie/security/code-scanning/1)

To fix the problem, we need to ensure that the type of the variable `counter` is at least as wide as the type of the result of `Long.bitCount(bucket)`, which is `int`. The best way to fix this without changing existing functionality is to change the type of `counter` from `short` to `int`. This will prevent any implicit narrowing conversion and avoid potential overflow issues.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
